### PR TITLE
Update install.sh to fix Ubuntu compilation and dependencies

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Stop script immediately if any command fails
+set -e
+
 echo "---------------------------------------------"
 echo "----------- Env Installation -----------"
 echo "---------------------------------------------"
@@ -30,7 +33,7 @@ CUDA_VERSION=12.4
 
 echo "Install PyTorch ${TORCH_VERSION} with CUDA ${CUDA_VERSION}"
 conda install pytorch=="${TORCH_VERSION}" torchvision=="${TV_VERSION}" torchaudio=="${TA_VERSION}" \
-  pytorch-cuda="${CUDA_VERSION}" -c pytorch -c nvidia -y
+  pytorch-cuda="${CUDA_VERSION}" cuda-toolkit="${CUDA_VERSION}" cuda-nvcc="${CUDA_VERSION}" cuda-compiler="${CUDA_VERSION}" gcc_linux-64=13 gxx_linux-64=13 cuda-cudart-dev="${CUDA_VERSION}" cuda-cccl="${CUDA_VERSION}" -c pytorch -c nvidia -c conda-forge -y
 
 python -c "import torch; print('torch:', torch.__version__, 'cuda:', torch.version.cuda, 'is_available:', torch.cuda.is_available())"
 
@@ -56,27 +59,46 @@ pip install -r requirements.txt
 # 4) Build your cpp_core wrappers
 # -------------------------
 echo "Build cpp_core wrappers"
+
+# Force C++ extensions to strictly use the Conda environment's CUDA toolkit
+export CUDA_HOME=$CONDA_PREFIX
+
+# Install missing build dependencies, forcing PCL 1.13+ and VTK
+conda install cmake make swig "pcl>=1.13" vtk libboost-python -c conda-forge -y
+
 pushd cpp_core/pcd_tiling
+sed -i 's/boost_python311/boost_python38/g' CMakeLists.txt
 bash generate_wraper.sh
 popd
 
 # install it when using supervoxel_seegmentation for partitioning
 pushd cpp_core/supervoxel_segmentation
+sed -i 's/boost_python311/boost_python38/g' CMakeLists.txt
 bash generate_wraper.sh
 popd
-
-# install packages 5-7 if using superpoint transformer for partitioning, reference: superpoint_transformer/install.sh
 
 # -------------------------
 # 5) FRNN (as in your script)
 # -------------------------
 echo "⭐ Installing FRNN"
-git clone git@github.com:zhaoyiww/superpoint_transformer.git
+# Remove any existing FRNN artifacts if the script failed previously
+rm -rf superpoint_transformer/src/dependencies/FRNN
+
+git clone https://github.com/zhaoyiww/superpoint_transformer.git || true
 cd superpoint_transformer
 mkdir -p src/dependencies
 if [ ! -d "src/dependencies/FRNN" ]; then
   git clone --recursive https://github.com/lxxue/FRNN.git src/dependencies/FRNN
 fi
+
+# Force the compiler to target known, stable GPU architectures and allow GCC 13
+export TORCH_CUDA_ARCH_LIST="6.0;6.1;7.0;7.5;8.0;8.6;8.9;9.0"
+export TORCH_NVCC_FLAGS="-allow-unsupported-compiler"
+export RELAXED_CUDA_VERSION_CHECK=1
+
+# Unset the flags that broke standard GCC just in case they are lingering
+unset CFLAGS
+unset CXXFLAGS
 
 pushd src/dependencies/FRNN/external/prefix_sum
 python setup.py install


### PR DESCRIPTION
This PR updates the `install.sh` script to resolve the compilation and dependency errors on Ubuntu setups, as discussed in the #2 .

**Changes included:**

- **Isolated the CUDA/C++ toolchain**: Added the full toolchain (`cuda-toolkit`, `gcc_linux-64=13`) to Conda and isolated it with` export CUDA_HOME=$CONDA_PREFIX` to prevent conflicts with Ubuntu's system compilers.

- **Added missing build dependencies**: Added explicit `conda install` for `cmake`, `swig`, `pcl>=1.13`, and `vtk` from `conda-forge` so the `cpp_core` wrappers build correctly.

- **Fixed Boost Python linker errors**: Added a `sed` command to dynamically replace the hardcoded `boost_python311` in `CMakeLists.txt` to match the actual Python 3.8 environment.

- **Updated Git clone protocol**: Switched the `superpoint_transformer` clone URL to HTTPS to prevent SSH permission denied errors.

- **Added fail-fast & cleanup**: Added `set -e` so the script halts immediately on failure, and a cleanup command for FRNN artifacts to prevent caching issues on repeated runs.

Fixes #2